### PR TITLE
older v1.5a2 version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,22 +13,22 @@ source:
   patches:   # [unix]
     - 0001-Allow-include-flags-to-be-present-in-CFLAGS.patch        # [unix]
     - 0002-Allow-library-flags-to-be-present-in-LDFLAGS.patch       # [unix]
-    - 0003-Do-not-use-hard-coded-path-for-file-command.patch        # [unix]
-    - 0004-Allow-macro-to-be-present-in-CFLAGS.patch                # [unix]
-    - 0005-Drop-isysroot-if-CONDA_BUILD_SYSROOT-is-specified.patch  # [unix]
+      #    - 0003-Do-not-use-hard-coded-path-for-file-command.patch        # [unix]
+      #  - 0004-Allow-macro-to-be-present-in-CFLAGS.patch                # [unix]
+      # - 0005-Drop-isysroot-if-CONDA_BUILD_SYSROOT-is-specified.patch  # [unix]
 
 build:
   number: 0
   script:
-    - export GEVENTSETUP_EMBED_LIBEV=0 GEVENTSETUP_EMBED_LIBUV=0 GEVENTSETUP_EMBED_CARES=0  # [unix]
+    #  - export GEVENTSETUP_EMBED_LIBEV=0 GEVENTSETUP_EMBED_LIBUV=0 GEVENTSETUP_EMBED_CARES=0  # [unix]
     - copy %SRC_DIR%\deps\c-ares\ares_build.h.dist %SRC_DIR%\deps\c-ares\ares_build.h       # [win]
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - libmagic  # [unix]
-    - make      # [unix]
+      #- libmagic  # [unix]
+      #- make      # [unix]
 
   host:
     # cffi 1.4.0 is the general minimum version
@@ -38,19 +38,19 @@ requirements:
     - cffi >=1.11.5
     - pip
     - python
-    - libev     # [unix]
-    - libuv     # [unix]
-    - c-ares    # [unix]
+      #- libev     # [unix]
+      #- libuv     # [unix]
+      #- c-ares    # [unix]
 
   run:
     - cffi >=1.11.5
     - python
-    - greenlet >=0.4.17,<2.0
-    - zope.event
-    - zope.interface
-    - setuptools
+    - greenlet >=0.4.14
+      #- zope.event
+      #- zope.interface
+      #- setuptools
     # xref: https://github.com/conda-forge/libuv-feedstock/issues/48
-    - {{ pin_compatible('libuv') }}  # [unix]
+    #- {{ pin_compatible('libuv') }}  # [unix]
 
 test:
   requires:
@@ -58,8 +58,8 @@ test:
   imports:
     - gevent
     - gevent.libev
-    - gevent.libuv
-    - gevent.resolver
+      #- gevent.libuv
+      #- gevent.resolver
   commands:
     - python -m pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   number: 0
   script:
-    #  - export GEVENTSETUP_EMBED_LIBEV=0 GEVENTSETUP_EMBED_LIBUV=0 GEVENTSETUP_EMBED_CARES=0  # [unix]
+    - export GEVENTSETUP_EMBED_LIBEV=0 GEVENTSETUP_EMBED_LIBUV=0 GEVENTSETUP_EMBED_CARES=0  # [unix]
     - copy %SRC_DIR%\deps\c-ares\ares_build.h.dist %SRC_DIR%\deps\c-ares\ares_build.h       # [win]
     - {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vvv
 
@@ -38,8 +38,8 @@ requirements:
     - cffi >=1.11.5
     - pip
     - python
-      #- libev     # [unix]
-      #- libuv     # [unix]
+    - libev     # [unix]
+    - libuv     # [unix]
       #- c-ares    # [unix]
 
   run:
@@ -50,7 +50,7 @@ requirements:
       #- zope.interface
       #- setuptools
     # xref: https://github.com/conda-forge/libuv-feedstock/issues/48
-    #- {{ pin_compatible('libuv') }}  # [unix]
+    - {{ pin_compatible('libuv') }}  # [unix]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,6 @@ source:
   patches:   # [unix]
     - 0001-Allow-include-flags-to-be-present-in-CFLAGS.patch        # [unix]
     - 0002-Allow-library-flags-to-be-present-in-LDFLAGS.patch       # [unix]
-      #    - 0003-Do-not-use-hard-coded-path-for-file-command.patch        # [unix]
-      #  - 0004-Allow-macro-to-be-present-in-CFLAGS.patch                # [unix]
-      # - 0005-Drop-isysroot-if-CONDA_BUILD_SYSROOT-is-specified.patch  # [unix]
 
 build:
   number: 0
@@ -27,8 +24,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-      #- libmagic  # [unix]
-      #- make      # [unix]
 
   host:
     # cffi 1.4.0 is the general minimum version
@@ -40,15 +35,11 @@ requirements:
     - python
     - libev     # [unix]
     - libuv     # [unix]
-      #- c-ares    # [unix]
 
   run:
     - cffi >=1.11.5
     - python
     - greenlet >=0.4.14
-      #- zope.event
-      #- zope.interface
-      #- setuptools
     # xref: https://github.com/conda-forge/libuv-feedstock/issues/48
     - {{ pin_compatible('libuv') }}  # [unix]
 
@@ -58,8 +49,6 @@ test:
   imports:
     - gevent
     - gevent.libev
-      #- gevent.libuv
-      #- gevent.resolver
   commands:
     - python -m pip check
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "gevent" %}
-{% set version = "21.1.2" %}
-{% set sha256 = "520cc2a029a9eef436e4e56b007af7859315cafa21937d43c1d5269f12f2c981" %}
+{% set version = "1.5a2" %}
+{% set sha256 = "9c6de6aa9365929d6747b6bf376aaf880553b1ca08c61fc8eef4ed4e31a7e34a" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
For a specific project, I need exactly this version, even though technically it is listed as pre-release. If possible, please merge into a new v.1.5x branch.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
